### PR TITLE
test(ctx): test case fail

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+GOPACKAGES = $(shell go list ./...  | grep -v /vendor/)
+
+test:
+	@go test -ldflags -s -v $(GOPACKAGES)
+
+
+.PHONY: test

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -1,0 +1,73 @@
+package ctx_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo"
+
+	"github.com/cutedogspark/echo-custom-context"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCustomCtx(t *testing.T) {
+	tt := []struct {
+		name         string
+		givenHandler func(c echo.Context) error
+		wantJSON     string
+	}{
+		{
+			name: "200",
+			givenHandler: func(c echo.Context) error {
+				return c.(ctx.CustomCtx).Resp(http.StatusOK).Data("hello world").Do()
+			},
+			wantJSON: `{"apiVersion": "v1", "data": "helle world"}`,
+		},
+		{
+			name: "400",
+			givenHandler: func(c echo.Context) error {
+
+				errCode := 40000001
+				errMsg := "Error Title"
+				errDate := ctx.NewErrors()
+				errDate.Add("Error Message 1")
+				errDate.Add("Error Message 2")
+
+				return c.(ctx.CustomCtx).Resp(errCode).Error(fmt.Sprintf("%v", errMsg)).Code(errCode).Errors(errDate.Error()).Do()
+			},
+			wantJSON: `{"apiVersion":"1.0","error":{"code":40000001,"message":"Error Title","errors":["Error Message 1","Error Message 2"]}}`,
+		},
+		{
+			name: "400 with error and errors",
+			givenHandler: func(c echo.Context) error {
+				errs := []interface{}{}
+				errs = append(errs, struct {
+					name string
+				}{"peter"})
+				return c.(ctx.CustomCtx).Resp(http.StatusOK).Error("this is error message").Errors(errs).Do()
+			},
+			wantJSON: `{"apiVersion":"v1","error":{"code":0, "message":"this is error message", "errors":[{"name":"peter"}]}}`,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			e := echo.New()
+
+			req := httptest.NewRequest(echo.GET, "/", nil)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			func(next echo.HandlerFunc) echo.HandlerFunc {
+				return func(c echo.Context) error {
+					return next(ctx.CustomCtx{c})
+				}
+			}(tc.givenHandler)(c)
+
+			t.Log(rec.Body.String())
+			assert.JSONEq(t, tc.wantJSON, rec.Body.String())
+		})
+	}
+}

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -7,9 +7,9 @@ import (
 	"testing"
 
 	"github.com/labstack/echo"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/cutedogspark/echo-custom-context"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestCustomCtx(t *testing.T) {
@@ -23,7 +23,7 @@ func TestCustomCtx(t *testing.T) {
 			givenHandler: func(c echo.Context) error {
 				return c.(ctx.CustomCtx).Resp(http.StatusOK).Data("hello world").Do()
 			},
-			wantJSON: `{"apiVersion": "v1", "data": "helle world"}`,
+			wantJSON: `{"apiVersion": "1.0", "data": "hello world"}`,
 		},
 		{
 			name: "400",
@@ -44,11 +44,11 @@ func TestCustomCtx(t *testing.T) {
 			givenHandler: func(c echo.Context) error {
 				errs := []interface{}{}
 				errs = append(errs, struct {
-					name string
+					Name string `json:"name"`
 				}{"peter"})
 				return c.(ctx.CustomCtx).Resp(http.StatusOK).Error("this is error message").Errors(errs).Do()
 			},
-			wantJSON: `{"apiVersion":"v1","error":{"code":0, "message":"this is error message", "errors":[{"name":"peter"}]}}`,
+			wantJSON: `{"apiVersion":"1.0","error":{"code":0, "message":"this is error message", "errors":[{"name":"peter"}]}}`,
 		},
 	}
 
@@ -66,7 +66,6 @@ func TestCustomCtx(t *testing.T) {
 				}
 			}(tc.givenHandler)(c)
 
-			t.Log(rec.Body.String())
 			assert.JSONEq(t, tc.wantJSON, rec.Body.String())
 		})
 	}


### PR DESCRIPTION
ctx Errors(errors []interface{}) does not marshal

```go
errs := []interface{}{}
errs = append(errs, struct {
	name string
}{"peter"})
return c.(ctx.CustomCtx).Resp(http.StatusOK).Error("this is error message").Errors(errs).Do()
```

```
$ make test
=== RUN   TestCustomCtx
=== RUN   TestCustomCtx/200
=== RUN   TestCustomCtx/400
=== RUN   TestCustomCtx/400_with_error_and_errors
--- FAIL: TestCustomCtx (0.00s)
    --- FAIL: TestCustomCtx/200 (0.00s)
    	ctx_test.go:69: {"apiVersion":"1.0","data":"hello world"}
        Error Trace:    ctx_test.go:70
    	Error:      	Not equal:
    	            	expected: map[string]interface {}{"apiVersion":"v1", "data":"helle world"}
    	            	received: map[string]interface {}{"apiVersion":"1.0", "data":"hello world"}

    	            	Diff:
    	            	--- Expected
    	            	+++ Actual
    	            	@@ -1,4 +1,4 @@
    	            	 (map[string]interface {}) (len=2) {
    	            	- (string) (len=10) "apiVersion": (string) (len=2) "v1",
    	            	- (string) (len=4) "data": (string) (len=11) "helle world"
    	            	+ (string) (len=10) "apiVersion": (string) (len=3) "1.0",
    	            	+ (string) (len=4) "data": (string) (len=11) "hello world"
    	            	 }
    --- PASS: TestCustomCtx/400 (0.00s)
    	ctx_test.go:69: {"apiVersion":"1.0","error":{"code":40000001,"message":"Error Title","errors":["Error Message 1","Error Message 2"]}}
    --- FAIL: TestCustomCtx/400_with_error_and_errors (0.00s)
    	ctx_test.go:69: {"apiVersion":"1.0","error":{"code":0,"message":"this is error message","errors":[{}]}}
        Error Trace:    ctx_test.go:70
    	Error:      	Not equal:
    	            	expected: map[string]interface {}{"apiVersion":"v1", "error":map[string]interface {}{"code":0, "message":"this is error message", "errors":[]interface {}{map[string]interface {}{"name":"peter"}}}}
    	            	received: map[string]interface {}{"apiVersion":"1.0", "error":map[string]interface {}{"code":0, "message":"this is error message", "errors":[]interface {}{map[string]interface {}{}}}}

    	            	Diff:
    	            	--- Expected
    	            	+++ Actual
    	            	@@ -1,3 +1,3 @@
    	            	 (map[string]interface {}) (len=2) {
    	            	- (string) (len=10) "apiVersion": (string) (len=2) "v1",
    	            	+ (string) (len=10) "apiVersion": (string) (len=3) "1.0",
    	            	  (string) (len=5) "error": (map[string]interface {}) (len=3) {
    	            	@@ -5,4 +5,3 @@
    	            	   (string) (len=6) "errors": ([]interface {}) (len=1) {
    	            	-   (map[string]interface {}) (len=1) {
    	            	-    (string) (len=4) "name": (string) (len=5) "peter"
    	            	+   (map[string]interface {}) {
    	            	    }
FAIL
FAIL	github.com/cutedogspark/echo-custom-context	0.012s
?   	github.com/cutedogspark/echo-custom-context/example	[no test files]
make: *** [test] Error 1
```