### PR TITLE
feat(gctx): add gctx for Google JSON style response

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -2,8 +2,6 @@ package ctx
 
 import (
 	"encoding/json"
-	"fmt"
-	"strconv"
 	"strings"
 
 	"github.com/labstack/echo"
@@ -127,51 +125,6 @@ func (r *errorCall) Errors(errors []interface{}) *errorCall {
 }
 
 func (r *errorCall) Do() (err error) {
-	b, err := json.Marshal(r.responseParams)
-	if err != nil {
-		return err
-	}
-	return r.c.JSONBlob(r.httpStatus, b)
-}
-
-// Google JSON Style error call
-type gerrorCall struct {
-	c              echo.Context
-	httpStatus     int
-	responseParams GErrorResponse
-}
-
-type gerrorMessage struct {
-	Code    int      `json:"code"`
-	Message string   `json:"message"`
-	Errors  []GError `json:"errors,omitempty"`
-}
-
-type GErrorResponse struct {
-	ApiVersion string        `json:"apiVersion"`
-	Error      gerrorMessage `json:"error"`
-}
-
-func (c CustomCtx) GError(errs ...GError) *gerrorCall {
-	rs := &gerrorCall{
-		c: echo.Context(c),
-		responseParams: GErrorResponse{
-			ApiVersion: apiVersion,
-			Error:      gerrorMessage{},
-		},
-	}
-
-	if len(errs) > 0 {
-		s, _ := strconv.Atoi(fmt.Sprintf("%d", errs[0].Code)[:3])
-		rs.httpStatus = s
-		rs.responseParams.Error.Code = errs[0].Code
-		rs.responseParams.Error.Message = errs[0].Message
-		rs.responseParams.Error.Errors = errs
-	}
-	return rs
-}
-
-func (r *gerrorCall) Do() (err error) {
 	b, err := json.Marshal(r.responseParams)
 	if err != nil {
 		return err

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -26,10 +26,17 @@ func TestCustomCtx(t *testing.T) {
 			wantJSON: `{"apiVersion": "1.0", "data": "hello world"}`,
 		},
 		{
+			name: "200 with google json style",
+			givenHandler: func(c echo.Context) error {
+				return c.(ctx.CustomCtx).GResp(http.StatusOK).Data("hello world").Do()
+			},
+			wantJSON: `{"apiVersion": "1.0", "data": "hello world"}`,
+		},
+		{
 			name: "400 with google json style",
 			givenHandler: func(c echo.Context) error {
 
-				gerr := ctx.NewGErrors().Append(ctx.GError{
+				gerrs := ctx.NewGErrors().Append(ctx.GError{
 					Code:         40000001,
 					Domain:       "Calendar",
 					Reason:       "ResourceNotFoundException",
@@ -47,7 +54,7 @@ func TestCustomCtx(t *testing.T) {
 					Location:     "part",
 				})
 
-				return c.(ctx.CustomCtx).GError(gerr...).Do()
+				return c.(ctx.CustomCtx).GResp().Errors(gerrs...).Do()
 			},
 			wantJSON: `{"apiVersion":"1.0","error":{"code":40000001,"message":"Resources is not exist","errors":[{"extendedHelp":"http://help-link", "sendReport":"http://report.dajui.com/", "domain":"Calendar", "reason":"ResourceNotFoundException", "message":"Resources is not exist", "location":"query", "locationType":"database query"},{"message":"Required parameter: part", "location":"part", "locationType":"parameter", "domain":"global", "reason":"required"}]}}`,
 		},

--- a/gctx.go
+++ b/gctx.go
@@ -1,0 +1,121 @@
+package ctx
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/labstack/echo"
+)
+
+type grespCall struct {
+	ver        string
+	c          echo.Context
+	httpStatus []int
+}
+
+func (c CustomCtx) GResp(httpStatus ...int) *grespCall {
+	rs := &grespCall{
+		ver:        apiVersion,
+		c:          echo.Context(c),
+		httpStatus: httpStatus,
+	}
+	return rs
+}
+
+type gdataCall struct {
+	c              echo.Context
+	httpStatus     int
+	responseParams SuccessResp
+}
+
+func (r *grespCall) Ver(ver string) *grespCall {
+	r.ver = ver
+	return r
+}
+
+func (r *grespCall) Data(data ...interface{}) *gdataCall {
+	var d interface{}
+	if len(data) == 0 {
+		d = []string{}
+	} else {
+		d = data[0]
+	}
+
+	rs := &gdataCall{
+		c:          r.c,
+		httpStatus: r.httpStatus[0],
+		responseParams: SuccessResp{
+			ApiVersion: r.ver,
+			Data:       d,
+		},
+	}
+	return rs
+}
+
+// Response Json Format
+// - replace string when response raw data
+// - ex: 	replace := strings.NewReplacer("{PP_KEY}", encryptionKey)
+func (r *gdataCall) Do(replace ...*strings.Replacer) (err error) {
+	b, err := json.Marshal(r.responseParams)
+	if err != nil {
+		return err
+	}
+	data := string(b)
+	for _, value := range replace {
+		data = value.Replace(data)
+	}
+
+	return r.c.JSONBlob(r.httpStatus, []byte(data))
+}
+
+// Google JSON Style error call
+type gerrorCall struct {
+	c              echo.Context
+	httpStatus     int
+	responseParams GErrorResponse
+}
+
+type gerrorMessage struct {
+	Code    uint     `json:"code"`
+	Message string   `json:"message"`
+	Errors  []GError `json:"errors,omitempty"`
+}
+
+type GErrorResponse struct {
+	ApiVersion string        `json:"apiVersion"`
+	Error      gerrorMessage `json:"error"`
+}
+
+func (r *grespCall) Errors(errs ...GError) *gerrorCall {
+	rs := &gerrorCall{
+		c: r.c,
+		responseParams: GErrorResponse{
+			ApiVersion: apiVersion,
+			Error:      gerrorMessage{},
+		},
+	}
+
+	if len(errs) > 0 {
+		if len(r.httpStatus) > 0 {
+			rs.httpStatus = r.httpStatus[0]
+		} else {
+			s, _ := strconv.Atoi(fmt.Sprintf("%d", errs[0].Code)[:3])
+			rs.httpStatus = s
+		}
+
+		rs.responseParams.Error.Code = errs[0].Code
+		rs.responseParams.Error.Message = errs[0].Message
+		rs.responseParams.Error.Errors = errs
+	}
+	return rs
+}
+
+func (r *gerrorCall) Do() (err error) {
+	b, err := json.Marshal(r.responseParams)
+	if err != nil {
+		return err
+	}
+	return r.c.JSONBlob(r.httpStatus, b)
+}

--- a/gerr.go
+++ b/gerr.go
@@ -3,7 +3,7 @@ package ctx
 type GErrors []GError
 
 type GError struct {
-	Code         int    `json:"-"`
+	Code         uint   `json:"-"`
 	Domain       string `json:"domain,omitempty"`
 	Reason       string `json:"reason,omitempty"`
 	Message      string `json:"message,omitempty"`
@@ -16,6 +16,10 @@ type GError struct {
 func (c GErrors) Append(gerr GError) GErrors {
 	c = append(c, gerr)
 	return c
+}
+
+func (c GErrors) Empty() bool {
+	return len(c) == 0
 }
 
 func NewGErrors() GErrors { return GErrors{} }


### PR DESCRIPTION
```go
return c.(ctx.CustomCtx).GResp(http.StatusOK).Data("hello world").Do()
```

```go
gerrs := ctx.NewGErrors().Append(ctx.GError{
    Code:         40000001,
    Domain:       "Calendar",
    Reason:       "ResourceNotFoundException",
    Message:      "Resources is not exist",
    LocationType: "database query",
    Location:     "query",
    ExtendedHelp: "http://help-link",
    SendReport:   "http://report.dajui.com/",
}).Append(ctx.GError{
    Code:         40000001,
    Domain:       "global",
    Reason:       "required",
    Message:      "Required parameter: part",
    LocationType: "parameter",
    Location:     "part",
})

return c.(ctx.CustomCtx).GResp().Errors(gerrs...).Do()
```